### PR TITLE
Fix and test bugs in openRoughScan

### DIFF
--- a/src/pre/_tests/test_images.py
+++ b/src/pre/_tests/test_images.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from pathlib import Path
 import configparser
+import pooch
 # from tempfile import TemporaryDirectory
 
 
@@ -86,7 +87,7 @@ def marker_ome_zarr(HSImage, demo_config, tmp_path_factory):
                    2:{740:'ELAVL2'},
                    3:{558:'LMNB1'},
                    4:{687:'MBP'},
-                   5:{558:'LMNB1', 610:'GFAP', 687:'MBP', 740:'ELAVL2'}
+                   5:{558:'LMNB1_5', 610:'GFAP_5', 687:'MBP_5', 740:'ELAVL2_5'}
     }
 
 
@@ -180,3 +181,44 @@ def test_get_HiSeqImages(demo_config):
     assert len(ims) == 2
     ims = ia.get_HiSeqImages(image_path, common_name='m3b', extra_config_path=demo_config)
     assert isinstance(ims, ia.HiSeqImages)
+
+
+@pytest.fixture(scope="session")
+def rough_scan_data():
+    """Download and cache RoughScan test data from Zenodo.
+
+    Returns:
+        Path: Path to the extracted RoughScan directory containing image files.
+              The directory contains:
+              - Image files: 12-bit TIFF files across 4 channels (558, 610, 687, 740)
+                with 3 tiles per channel (tile IDs: 10292, 10607, 10922)
+              - Metadata files: .txt files with scan parameters
+    """
+    # Use pooch's default cache directory (~/.cache/pyseq2500)
+    data_path = pooch.os_cache("pyseq2500")
+
+    # Create a pooch instance for the Zenodo dataset
+    rough_pooch = pooch.create(
+        path=data_path,
+        base_url="https://zenodo.org/record/19355899/files/",
+        registry={"RoughScan.tar.gz": None},  # None skips checksum for now
+    )
+
+    # Download the tarball (cached after first download)
+    tarball_path = rough_pooch.fetch("RoughScan.tar.gz", processor=None)
+
+    # Extract the tarball
+    extract_dir = data_path / "RoughScan"
+    if not extract_dir.exists():
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            tar.extractall(path=data_path)
+
+    return extract_dir
+
+def test_open_rough_scan(rough_scan_data):
+    im = ia.HiSeqImages.open_RoughScan(rough_scan_data, suffix = "tif")
+    assert im.im.shape ==  (4, 4544, 6144)
+    assert im.im.dims == ('channel', 'row', 'col')
+    assert "background" in im.config
+    assert "OME" in im.config
+    

--- a/src/pre/image_analysis.py
+++ b/src/pre/image_analysis.py
@@ -522,7 +522,8 @@ def get_machine_config(machine, extra_config_path=None, **kwargs):
       config_path: Machine settings config path (str)
     '''
 
-    config_paths = [Path.home() / '.config/pyseq2500/machine_settings',
+    config_paths = [Path.home() / '.config/pyseq/machine_settings',
+                    Path.home() / '.config/pyseq2500/machine_settings',
                     Path.home() / '.pyseq2500/machine_settings']
     if extra_config_path is not None:
         config_paths.insert(0, Path(extra_config_path))
@@ -544,6 +545,8 @@ def get_machine_config(machine, extra_config_path=None, **kwargs):
 
         if config_path.suffix == '.yaml':
             config = config.get(machine, None)
+            if isinstance(config, dict) and "image" in config:
+                config = config["image"]
         elif config_path.suffix == '.cfg':
             machine = str(machine).lower()
             if machine not in config.options('machines'):
@@ -808,17 +811,23 @@ class HiSeqImages():
         #     self.name = im.name
 
     def assign_machine(self):
-        config_path = Path.home() / '.config/pyseq2500/machine_settings.yaml'
-        if isinstance(self.files, list):
-            name_path = self.files[0].parent/'machine_name.txt'
-            if name_path.exists():
-                with open(name_path,'r') as f:
-                    self.machine = f.readline().strip()
-        elif config_path.exists():
-            config = get_config(config_path)
-            self.machine = config.get('name', None)
-        else:
-            logger.warning('Could not assign machine')
+        config_paths = [Path.home() / '.config/pyseq/machine_settings.yaml',
+                        Path.home() / '.config/pyseq2500/machine_settings.yaml']
+        
+        for config_path in config_paths:
+            if isinstance(self.files, list) and len(self.files) > 0:
+                name_path = self.files[0].parent/'machine_name.txt'
+                if name_path.exists():
+                    with open(name_path,'r') as f:
+                        self.machine = f.readline().strip()
+                    break
+            elif config_path.exists():
+                config = get_config(config_path)
+                self.machine = config.get('name', None)
+                break
+
+        if self.machine is None:
+                logger.warning('Could not assign machine')
 
         self.im.attrs['machine'] = self.machine
 
@@ -1545,21 +1554,23 @@ class HiSeqImages():
 
 
     @classmethod
-    def open_RoughScan(cls, path, **kwargs):
+    def open_RoughScan(cls, path: str, suffix: str = "tiff" , name: str = "RoughScan"):
+
 
         # Open RoughScan tiffs
-        files = get_image_files(path, 'zarr', 'RoughScan')
+        files = get_image_files(path, suffix, name)
 
 
         comp_sets = dict()
         for f in files:
             # Break up filename into components
-            comp_ = f.stem
+            comp_ = f.stem.split("_")
             for i, comp in enumerate(comp_):
                 comp_sets.setdefault(i,set())
                 comp_sets[i].add(comp)
 
-        shape = imageio.imread(files[0]).shape
+
+        shape = imageio.v2.imread(files[0]).shape
         lazy_arrays = [dask.delayed(imageio.imread)(f) for f in files]
         lazy_arrays = [da.from_delayed(x, shape=shape, dtype='int16') for x in lazy_arrays]
 
@@ -1573,7 +1584,7 @@ class HiSeqImages():
         remap_comps = [fn_comp_sets[0], [1], fn_comp_sets[2]]
         a = np.empty(tuple(map(len, remap_comps)), dtype=object)
         for f, x in zip(files, lazy_arrays):
-            comp_ = f.stem
+            comp_ = f.stem.split("_")
             channel = fn_comp_sets[0].index(int(comp_[0][1:]))
             x_step = fn_comp_sets[2].index(int(comp_[2][1:]))
             a[channel, 0, x_step] = x
@@ -1593,6 +1604,8 @@ class HiSeqImages():
                              overlap=0, fixed_bg = 0)
         # Remove top header
         im = im.sel(row=slice(64,None))
+
+        print(im)
         
         hsim = cls(im)
         hsim.files = files


### PR DESCRIPTION
open RoughScan was not able to open rough scan images

fixed a few bugs
added arguments to specify suffix and name of images to make it more flexible
modified get_machine_config and assign_machine to look in ~/.config/pyseq 